### PR TITLE
fix: getCategoryPost category if조건 비교 구문 수정

### DIFF
--- a/src/main/java/com/gamecrew/gamecrew_project/domain/post/service/PostService.java
+++ b/src/main/java/com/gamecrew/gamecrew_project/domain/post/service/PostService.java
@@ -84,8 +84,7 @@ public class PostService {
         Sort sort = Sort.by(direction, sortBy,"title");
         Pageable pageable = PageRequest.of(page, size, sort);
 
-
-        if(!(category == "all")){
+        if(("all".equals(category))){
             Page<Post> postList = postRepository.findAll(pageable);
 
             List<PostResponseDto> postResponseDtoList = postList.stream()


### PR DESCRIPTION
Java에서 문자열 비교를 할 때는 == 연산자를 사용하면 안됨
 category == "all" -> ("all".equals(category))
으로 수정, 잘 작동 됨